### PR TITLE
[APP-6812] - remove removeclippedsubviews prop from flatlist

### DIFF
--- a/packages/uikit-react-native/src/components/ChatFlatList/index.tsx
+++ b/packages/uikit-react-native/src/components/ChatFlatList/index.tsx
@@ -63,7 +63,6 @@ const ChatFlatList = forwardRef<RNFlatList, Props>(function ChatFlatList(
   return (
     <FlatListInternal
       bounces={false}
-      removeClippedSubviews
       keyboardDismissMode={'on-drag'}
       keyboardShouldPersistTaps={'handled'}
       indicatorStyle={select({ light: 'black', dark: 'white' })}


### PR DESCRIPTION
## Description

<img width="1050" alt="Untitled" src="https://github.com/gathertown/sendbird-uikit-react-native/assets/18584664/3a17b63d-4460-4bb0-baf0-41cfc57dbcd4">
The prop is buggy for iOS. It defaults to true for android, so just removing it here will only remove it for iOS.

## Test Plan
Build package and use in gather.
Verify, with an iOS device, that you see the first message.