### PR TITLE
[APP-7111] - fork changes to support provider render prop

### DIFF
--- a/packages/uikit-react-native-foundation/src/context/CustomComponentCtx.tsx
+++ b/packages/uikit-react-native-foundation/src/context/CustomComponentCtx.tsx
@@ -61,6 +61,8 @@ export type SendInputRenderProp = (props: {
   ref: React.Ref<TextInput>;
 }) => React.ReactElement;
 
+export type CustomProvidersRenderProp = ({ children }: { children: React.ReactElement }) => React.ReactElement;
+
 export type CustomComponentContextType = {
   renderIncomingMessageContainer?: IncomingMessageContainerRenderProp;
   renderOutgoingMessageContainer?: OutgoingMessageContainerRenderProp;
@@ -78,6 +80,7 @@ export type CustomComponentContextType = {
     renderEditInput: EditInputRenderProp;
     renderSendInput: SendInputRenderProp;
   };
+  renderCustomProviders?: CustomProvidersRenderProp;
 };
 
 type Props = React.PropsWithChildren<CustomComponentContextType>;

--- a/packages/uikit-react-native-foundation/src/context/CustomProvidersRenderer.tsx
+++ b/packages/uikit-react-native-foundation/src/context/CustomProvidersRenderer.tsx
@@ -1,0 +1,15 @@
+import React, { useContext } from 'react';
+
+import { CustomComponentContext } from './CustomComponentCtx';
+
+const CustomProvidersRenderer = React.memo<{ children: React.ReactElement }>(function CustomProviderRenderer({
+  children,
+}) {
+  const ctx = useContext(CustomComponentContext);
+  if (ctx?.renderCustomProviders) {
+    return ctx.renderCustomProviders({ children });
+  }
+  return children;
+});
+
+export default CustomProvidersRenderer;

--- a/packages/uikit-react-native-foundation/src/index.ts
+++ b/packages/uikit-react-native-foundation/src/index.ts
@@ -62,6 +62,7 @@ export { default as useUIKitTheme } from './theme/useUIKitTheme';
 
 /** Context **/
 export { CustomComponentProvider, CustomComponentContext } from './context/CustomComponentCtx';
+export { default as CustomProvidersRenderer } from './context/CustomProvidersRenderer';
 export type {
   UnknownMessageRenderProp,
   GenericMessageRenderProp,

--- a/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
+++ b/packages/uikit-react-native/src/containers/SendbirdUIKitContainer.tsx
@@ -5,6 +5,7 @@ import type {
 } from '@gathertown/uikit-react-native-foundation';
 import {
   CustomComponentProvider,
+  CustomProvidersRenderer,
   DialogProvider,
   Header,
   HeaderStyleProvider,
@@ -33,7 +34,7 @@ import { SBUConfig, UIKitConfigProvider } from '@sendbird/uikit-tools';
 
 import { LocalizationContext, LocalizationProvider } from '../contexts/LocalizationCtx';
 import { PlatformServiceProvider } from '../contexts/PlatformServiceCtx';
-import { ReactionProvider } from '../contexts/ReactionCtx';
+import { ReactionBottomSheetsWrapper, ReactionProvider } from '../contexts/ReactionCtx';
 import type { ChatRelatedFeaturesInUIKit } from '../contexts/SendbirdChatCtx';
 import { SendbirdChatProvider } from '../contexts/SendbirdChatCtx';
 import { UserProfileProvider } from '../contexts/UserProfileCtx';
@@ -226,14 +227,14 @@ const SendbirdUIKitContainer = ({
           enableImageCompression={chatOptions.enableImageCompression ?? SendbirdUIKit.DEFAULT.IMAGE_COMPRESSION}
         >
           <LocalizationProvider stringSet={defaultStringSet}>
-            <CustomComponentProvider {...customRenderProps}>
-              <PlatformServiceProvider
-                fileService={platformServices.file}
-                notificationService={platformServices.notification}
-                clipboardService={platformServices.clipboard}
-                mediaService={platformServices.media}
-              >
-                <UIKitThemeProvider theme={styles?.theme ?? LightUIKitTheme}>
+            <UIKitThemeProvider theme={styles?.theme ?? LightUIKitTheme}>
+              <CustomComponentProvider {...customRenderProps}>
+                <PlatformServiceProvider
+                  fileService={platformServices.file}
+                  notificationService={platformServices.notification}
+                  clipboardService={platformServices.clipboard}
+                  mediaService={platformServices.media}
+                >
                   <HeaderStyleProvider
                     HeaderComponent={styles?.HeaderComponent ?? Header}
                     defaultTitleAlign={styles?.defaultHeaderTitleAlign ?? 'left'}
@@ -246,32 +247,37 @@ const SendbirdUIKitContainer = ({
                         statusBarTranslucent={styles?.statusBarTranslucent ?? true}
                       >
                         <ReactionProvider>
-                          <LocalizationContext.Consumer>
-                            {(value) => {
-                              const STRINGS = value?.STRINGS || defaultStringSet;
-                              return (
-                                <DialogProvider
-                                  defaultLabels={{
-                                    alert: { ok: STRINGS.DIALOG.ALERT_DEFAULT_OK },
-                                    prompt: {
-                                      ok: STRINGS.DIALOG.PROMPT_DEFAULT_OK,
-                                      cancel: STRINGS.DIALOG.PROMPT_DEFAULT_CANCEL,
-                                      placeholder: STRINGS.DIALOG.PROMPT_DEFAULT_PLACEHOLDER,
-                                    },
-                                  }}
-                                >
-                                  {renderChildren()}
-                                </DialogProvider>
-                              );
-                            }}
-                          </LocalizationContext.Consumer>
+                          <CustomProvidersRenderer>
+                            <>
+                              <LocalizationContext.Consumer>
+                                {(value) => {
+                                  const STRINGS = value?.STRINGS || defaultStringSet;
+                                  return (
+                                    <DialogProvider
+                                      defaultLabels={{
+                                        alert: { ok: STRINGS.DIALOG.ALERT_DEFAULT_OK },
+                                        prompt: {
+                                          ok: STRINGS.DIALOG.PROMPT_DEFAULT_OK,
+                                          cancel: STRINGS.DIALOG.PROMPT_DEFAULT_CANCEL,
+                                          placeholder: STRINGS.DIALOG.PROMPT_DEFAULT_PLACEHOLDER,
+                                        },
+                                      }}
+                                    >
+                                      {renderChildren()}
+                                    </DialogProvider>
+                                  );
+                                }}
+                              </LocalizationContext.Consumer>
+                              <ReactionBottomSheetsWrapper />
+                            </>
+                          </CustomProvidersRenderer>
                         </ReactionProvider>
                       </UserProfileProvider>
                     </ToastProvider>
                   </HeaderStyleProvider>
-                </UIKitThemeProvider>
-              </PlatformServiceProvider>
-            </CustomComponentProvider>
+                </PlatformServiceProvider>
+              </CustomComponentProvider>
+            </UIKitThemeProvider>
           </LocalizationProvider>
         </SendbirdChatProvider>
       </UIKitConfigProvider>


### PR DESCRIPTION
## Description
We have a use case that requires injecting a Provider that wraps the sendbird `Dialog` component. This component wraps the entire app and provides modal/bottomsheet capability.
We could've scoped this to just Dialog but the problem is the ReactionProvider renders its own version of the bottom sheet so we need to wrap that as well.

## Test Plan
Can smoke test that the changes didn't break the default
Long press on a message to verify that the default bottom sheet is rendered.
Long press an emoji on a message to verify that the reaction bottom sheet is rendered.