### PR TITLE
Add render prop to render custom new messages / scroll to bottom button APP-7080

### DIFF
--- a/packages/uikit-react-native-foundation/src/context/CustomComponentCtx.tsx
+++ b/packages/uikit-react-native-foundation/src/context/CustomComponentCtx.tsx
@@ -63,6 +63,12 @@ export type SendInputRenderProp = (props: {
 
 export type CustomProvidersRenderProp = ({ children }: { children: React.ReactElement }) => React.ReactElement;
 
+export type CombinedNewMessagesScrollToBottomButtonRenderProp = (props: {
+  visible: boolean;
+  onPress: () => void;
+  newMessagesCount: number;
+}) => React.ReactElement;
+
 export type CustomComponentContextType = {
   renderIncomingMessageContainer?: IncomingMessageContainerRenderProp;
   renderOutgoingMessageContainer?: OutgoingMessageContainerRenderProp;
@@ -81,6 +87,7 @@ export type CustomComponentContextType = {
     renderSendInput: SendInputRenderProp;
   };
   renderCustomProviders?: CustomProvidersRenderProp;
+  renderCombinedNewMessagesScrollToBottomButton?: CombinedNewMessagesScrollToBottomButtonRenderProp;
 };
 
 type Props = React.PropsWithChildren<CustomComponentContextType>;

--- a/packages/uikit-react-native-foundation/src/index.ts
+++ b/packages/uikit-react-native-foundation/src/index.ts
@@ -102,4 +102,5 @@ export type {
   ReactionBottomSheetUserListRenderProp,
   EditInputRenderProp,
   SendInputRenderProp,
+  CombinedNewMessagesScrollToBottomButtonRenderProp,
 } from './context/CustomComponentCtx';

--- a/packages/uikit-react-native/src/components/ChannelMessageList/index.tsx
+++ b/packages/uikit-react-native/src/components/ChannelMessageList/index.tsx
@@ -1,4 +1,4 @@
-import React, { Ref } from 'react';
+import React, { useContext, Ref } from 'react';
 import { FlatList, FlatListProps, ListRenderItem, View } from 'react-native';
 import { useSafeAreaInsets } from 'react-native-safe-area-context';
 
@@ -10,6 +10,7 @@ import {
   useBottomSheet,
   useToast,
   useUIKitTheme,
+  CustomComponentContext
 } from '@gathertown/uikit-react-native-foundation';
 import {
   Logger,
@@ -130,6 +131,7 @@ const ChannelMessageList = <T extends SendbirdGroupChannel | SendbirdOpenChannel
     onResendFailedMessage,
     onPressMediaMessage,
   });
+  const { renderCombinedNewMessagesScrollToBottomButton } = useContext(CustomComponentContext);
 
   const safeAreaLayout = { paddingLeft: left, paddingRight: right };
 
@@ -170,7 +172,16 @@ const ChannelMessageList = <T extends SendbirdGroupChannel | SendbirdOpenChannel
           flatListProps?.contentContainerStyle,
         ]}
       />
-      {renderNewMessagesButton && (
+      {renderCombinedNewMessagesScrollToBottomButton && (
+        <View style={[styles.newMsgButton, safeAreaLayout]}>
+          {renderCombinedNewMessagesScrollToBottomButton({
+            visible: hasNext() || scrolledAwayFromBottom,
+            onPress: () => newMessages.length > 0 ? onPressNewMessagesButton() : onPressScrollToBottomButton(),
+            newMessagesCount: newMessages.length,
+          })}
+        </View>
+      )}
+      {renderNewMessagesButton && !renderCombinedNewMessagesScrollToBottomButton && (
         <View style={[styles.newMsgButton, safeAreaLayout]}>
           {renderNewMessagesButton({
             visible: newMessages.length > 0 && (hasNext() || scrolledAwayFromBottom),
@@ -179,7 +190,7 @@ const ChannelMessageList = <T extends SendbirdGroupChannel | SendbirdOpenChannel
           })}
         </View>
       )}
-      {renderScrollToBottomButton && (
+      {renderScrollToBottomButton && !renderCombinedNewMessagesScrollToBottomButton && (
         <View style={[styles.scrollButton, safeAreaLayout]}>
           {renderScrollToBottomButton({
             visible: hasNext() || scrolledAwayFromBottom,
@@ -317,7 +328,7 @@ const useGetMessagePressActions = <T extends SendbirdGroupChannel | SendbirdOpen
 
           pushCopySheetItem(msg);
         }
-        
+
         sheetItems.push({
           disabled: msg.threadInfo ? msg.threadInfo.replyCount > 0 : undefined,
           icon: 'delete',


### PR DESCRIPTION
## Description

Adding a render prop so we can render a single button rather than two separate buttons to go to new messages and the bottom of the message list.

## Test Plan

With the Gather app:

<img width="564" alt="Screenshot 2024-05-07 at 3 43 44 PM" src="https://github.com/gathertown/sendbird-uikit-react-native/assets/866083/f538889a-e3fd-4e05-8725-2a98d995223d">

<img width="520" alt="Screenshot 2024-05-07 at 3 43 50 PM" src="https://github.com/gathertown/sendbird-uikit-react-native/assets/866083/9ee62352-c85f-4b90-81b0-1d219017f9e1">
