### PR TITLE
Add a render prop for overriding showing toasts APP-7120

### DIFF
--- a/packages/uikit-react-native-foundation/src/context/CustomComponentCtx.tsx
+++ b/packages/uikit-react-native-foundation/src/context/CustomComponentCtx.tsx
@@ -69,6 +69,9 @@ export type CombinedNewMessagesScrollToBottomButtonRenderProp = (props: {
   newMessagesCount: number;
 }) => React.ReactElement;
 
+export type ToastType = 'normal' | 'error' | 'success';
+export type ShowToastRenderProp = (text: string, type?: ToastType) => void;
+
 export type CustomComponentContextType = {
   renderIncomingMessageContainer?: IncomingMessageContainerRenderProp;
   renderOutgoingMessageContainer?: OutgoingMessageContainerRenderProp;
@@ -88,6 +91,7 @@ export type CustomComponentContextType = {
   };
   renderCustomProviders?: CustomProvidersRenderProp;
   renderCombinedNewMessagesScrollToBottomButton?: CombinedNewMessagesScrollToBottomButtonRenderProp;
+  renderToast?: ShowToastRenderProp;
 };
 
 type Props = React.PropsWithChildren<CustomComponentContextType>;

--- a/packages/uikit-react-native-foundation/src/index.ts
+++ b/packages/uikit-react-native-foundation/src/index.ts
@@ -103,4 +103,6 @@ export type {
   EditInputRenderProp,
   SendInputRenderProp,
   CombinedNewMessagesScrollToBottomButtonRenderProp,
+  ShowToastRenderProp,
+  ToastType,
 } from './context/CustomComponentCtx';

--- a/packages/uikit-react-native-foundation/src/ui/Toast/index.tsx
+++ b/packages/uikit-react-native-foundation/src/ui/Toast/index.tsx
@@ -6,9 +6,9 @@ import Icon from '../../components/Icon';
 import Text from '../../components/Text';
 import createStyleSheet from '../../styles/createStyleSheet';
 import useUIKitTheme from '../../theme/useUIKitTheme';
+import { CustomComponentContext, ShowToastRenderProp, ToastType } from "../../context/CustomComponentCtx";
 
-type ToastType = 'normal' | 'error' | 'success';
-type Context = { show(text: string, type?: ToastType): void };
+type Context = { show: ShowToastRenderProp };
 
 const ToastContext = createContext<Context | null>(null);
 
@@ -102,6 +102,10 @@ export const ToastProvider = ({
 
 export const useToast = () => {
   const context = useContext(ToastContext);
+  const customContext = useContext(CustomComponentContext);
+  if (customContext?.renderToast) {
+    return { show: customContext.renderToast };
+  }
   if (!context) throw new Error('ToastContext is not provided, wrap your app with ToastProvider');
   return context;
 };


### PR DESCRIPTION
## Description

Adding a new renderprop so we can control how toasts are shown.

## Test Plan

With the Gather app:

<img width="564" alt="Screenshot 2024-05-08 at 10 53 51 AM" src="https://github.com/gathertown/sendbird-uikit-react-native/assets/866083/e60f563c-b4d5-437f-a52d-e1b69552da19">
