### PR TITLE
Fix error when deleting last message in thread

### DIFF
--- a/packages/uikit-react-native/src/components/ChatFlatList/index.tsx
+++ b/packages/uikit-react-native/src/components/ChatFlatList/index.tsx
@@ -52,7 +52,7 @@ const ChatFlatList = forwardRef<RNFlatList, Props>(function ChatFlatList(
   });
 
   useEffect(() => {
-    if (data && data.length < prevDataLength.current) {
+    if (data && data.length > 0 && data.length < prevDataLength.current) {
       if (contentOffsetY.current === 0) {
         setTimeout(() => {
           if (typeof ref !== 'function') {


### PR DESCRIPTION
## Description

This fixes an error when we delete the last message in a thread. In this case, there are no items in the flatlist, so trying to scroll to index 0 throws an exception.

## Test Plan

Delete last message in a thread and verify no error is thrown.