### PR TITLE
[APP-7186] - fix photo slow load

### DIFF
--- a/packages/uikit-react-native-foundation/src/components/ImageWithPlaceholder/index.tsx
+++ b/packages/uikit-react-native-foundation/src/components/ImageWithPlaceholder/index.tsx
@@ -86,7 +86,7 @@ const ImageWithPlaceholder = (props: Props) => {
           />
         )
       }
-      {imageNotFound && (
+      {imageNotFound && !props.cachedSource && (
         <Icon
           containerStyle={StyleSheet.absoluteFill}
           icon={'thumbnail-none'}

--- a/packages/uikit-react-native-foundation/src/components/ImageWithPlaceholder/index.tsx
+++ b/packages/uikit-react-native-foundation/src/components/ImageWithPlaceholder/index.tsx
@@ -8,6 +8,7 @@ import useUIKitTheme from '../../theme/useUIKitTheme';
 import Box from '../Box';
 import Icon from '../Icon';
 import Image from '../Image';
+import LoadingSpinner from '../../ui/LoadingSpinner';
 
 const useRetry = (hasError: boolean, retryCount = 5) => {
   // NOTE: Glide(fast-image) will retry automatically on Android
@@ -43,26 +44,48 @@ type Props = {
   width?: number | string;
   height?: number | string;
   style?: StyleProp<ViewStyle>;
+  cachedSource?: string;
 };
 const ImageWithPlaceholder = (props: Props) => {
   const { palette, select, colors } = useUIKitTheme();
   const [imageNotFound, setImageNotFound] = useState(false);
-
+  const [loading, setLoading] = useState(true);
+  
   const key = useRetry(imageNotFound);
   return (
     <Box
-      style={[{ overflow: 'hidden', width: props.width, height: props.height }, props.style]}
+      style={[{ overflow: 'hidden', width: props.width, height: props.height }, props.style, styles.container]}
       backgroundColor={select({ dark: palette.background400, light: palette.background100 })}
     >
+      {loading && <LoadingSpinner />}
       <Image
         key={key}
         source={props.source}
         style={[StyleSheet.absoluteFill, imageNotFound && styles.hide]}
         resizeMode={'cover'}
         resizeMethod={'resize'}
-        onError={() => setImageNotFound(true)}
-        onLoad={() => setImageNotFound(false)}
+        onError={() => {
+          setLoading(false);
+          setImageNotFound(true);
+        }}
+        onLoad={() => {
+          setLoading(false);
+          setImageNotFound(false);
+        }}
       />
+      {
+        props.cachedSource && (loading || imageNotFound) && (
+          <Image
+            key={`local-${key}`}
+            source={{
+              uri: props.cachedSource,
+            }}
+            style={StyleSheet.absoluteFill}
+            resizeMode={'cover'}
+            resizeMethod={'resize'}
+          />
+        )
+      }
       {imageNotFound && (
         <Icon
           containerStyle={StyleSheet.absoluteFill}
@@ -76,6 +99,11 @@ const ImageWithPlaceholder = (props: Props) => {
 };
 
 const styles = createStyleSheet({
+  container: {
+    justifyContent: 'center',
+    alignItems: 'center',
+    borderRadius: 0,
+  },
   hide: {
     display: 'none',
   },

--- a/packages/uikit-react-native-foundation/src/context/LocalImageContext.tsx
+++ b/packages/uikit-react-native-foundation/src/context/LocalImageContext.tsx
@@ -1,0 +1,31 @@
+import {  getThumbnailUriFromFileMessage } from '@gathertown/uikit-utils';
+import { FileMessage } from '@sendbird/chat/message';
+import React, { useContext, useMemo  } from 'react';
+
+type LocalImageContextType = Record<string, string>
+
+export const LocalImageContext = React.createContext<LocalImageContextType | null>(null);
+
+export const useLocalImageCache = (message: FileMessage) => {
+  const localImageContext = useContext(LocalImageContext);
+
+  if (!localImageContext) {
+    console.warn('Missing local image context');
+    return;
+  }
+
+  if (message && message.sendingStatus === 'pending') {
+    localImageContext[message.reqId] = getThumbnailUriFromFileMessage(message);
+  }
+
+  return localImageContext[message.reqId];
+};
+
+export const LocalImageProvider = ({ children }: { children: React.ReactNode}) => {
+  const cache = useMemo(() => ({}), []);
+  return (
+    <LocalImageContext.Provider value={cache}>
+      {children}
+    </LocalImageContext.Provider>
+  );
+};

--- a/packages/uikit-react-native-foundation/src/index.ts
+++ b/packages/uikit-react-native-foundation/src/index.ts
@@ -106,3 +106,5 @@ export type {
   ShowToastRenderProp,
   ToastType,
 } from './context/CustomComponentCtx';
+
+export { LocalImageProvider } from './context/LocalImageContext';

--- a/packages/uikit-react-native-foundation/src/ui/GroupChannelMessage/Message.file.image.tsx
+++ b/packages/uikit-react-native-foundation/src/ui/GroupChannelMessage/Message.file.image.tsx
@@ -11,15 +11,16 @@ import useUIKitTheme from '../../theme/useUIKitTheme';
 import MessageContainer from './MessageContainer';
 import type { GroupChannelMessageProps } from './index';
 import { CustomComponentContext } from '../../context/CustomComponentCtx';
+import { useLocalImageCache } from '../../context/LocalImageContext';
 
 const ImageFileMessage = (props: GroupChannelMessageProps<SendbirdFileMessage>) => {
   const { onPress, onLongPress, variant = 'incoming' } = props;
   const ctx = useContext(CustomComponentContext);
+  const localImage = useLocalImageCache(props.message);
 
   const { colors } = useUIKitTheme();
-
   const content = (
-    <ImageWithPlaceholder source={{ uri: getThumbnailUriFromFileMessage(props.message) }} style={styles.image} />
+    <ImageWithPlaceholder source={{ uri: getThumbnailUriFromFileMessage(props.message) }} cachedSource={localImage} style={styles.image} />
   );
 
   return (

--- a/packages/uikit-react-native/src/domain/groupChannel/component/GroupChannelMessageList.tsx
+++ b/packages/uikit-react-native/src/domain/groupChannel/component/GroupChannelMessageList.tsx
@@ -2,7 +2,7 @@ import React, { useContext, useEffect, useRef } from 'react';
 import type { FlatList } from 'react-native';
 
 import { useChannelHandler } from '@gathertown/uikit-chat-hooks';
-import { useToast } from '@gathertown/uikit-react-native-foundation';
+import { useToast, LocalImageProvider } from '@gathertown/uikit-react-native-foundation';
 import type { SendbirdMessage } from '@gathertown/uikit-utils';
 import { isDifferentChannel, useFreshCallback, useIsFirstMount, useUniqHandlerId } from '@gathertown/uikit-utils';
 
@@ -117,15 +117,17 @@ const GroupChannelMessageList = (props: GroupChannelProps['MessageList']) => {
   });
 
   return (
-    <ChannelMessageList
-      {...props}
-      ref={ref}
-      onReplyMessage={setMessageToReply}
-      onEditMessage={setMessageToEdit}
-      onPressParentMessage={onPressParentMessage}
-      onPressNewMessagesButton={scrollToBottom}
-      onPressScrollToBottomButton={scrollToBottom}
-    />
+    <LocalImageProvider>
+      <ChannelMessageList
+        {...props}
+        ref={ref}
+        onReplyMessage={setMessageToReply}
+        onEditMessage={setMessageToEdit}
+        onPressParentMessage={onPressParentMessage}
+        onPressNewMessagesButton={scrollToBottom}
+        onPressScrollToBottomButton={scrollToBottom}
+        />
+    </LocalImageProvider>
   );
 };
 


### PR DESCRIPTION
## Description
Add loading states for images.
Gracefully transition local photo messages as they transition from pending to succeeded.


## Test Plan
Send a message. It should never render spinner.

https://github.com/gathertown/sendbird-uikit-react-native/assets/18584664/9d038550-2751-4b33-85c2-6b3da3e0fecd

Receive a message. Verify it renders a spinner

https://github.com/gathertown/sendbird-uikit-react-native/assets/18584664/5148e9ea-69a3-48e9-963e-575c3390eefe


