### PR TITLE
Fix mime type processing for iOS photos

### DIFF
--- a/packages/uikit-utils/src/shared/file.ts
+++ b/packages/uikit-utils/src/shared/file.ts
@@ -158,7 +158,12 @@ export function getFileExtensionFromMime(mimeType?: string | null): string {
     return acc;
   }, {} as Record<string, string>);
 
-  const extension = MIME_EXTENSION_MAP[mimeType.toLowerCase()];
+  const additional_entries = {
+    // iOS photos come back with a MIME type of "image/jpg", which is not an official MIME type, so special
+    // casing it here.
+    'image/jpg': 'jpg',
+  };
+  const extension = {MIME_EXTENSION_MAP, ...additional_entries}[mimeType.toLowerCase()];
   if (extension) return '.' + extension;
   return '';
 }


### PR DESCRIPTION
## Description

MIME types coming back from iOS photos are `image/jpg`, which isn't handled correctly with `EXTENSION_MIME_MAP`. Since `image/jpg` is not an official MIME type, adding special code to handle it here rather than modifying the original map. This change is needed because the MIME type needs to be [mapped to a file extension](https://github.com/sendbird/sendbird-uikit-react-native/blob/c789fbe8c681c283e95a6cd8309dfb87d415f16c/packages/uikit-react-native/src/hooks/useChannelInputItems.ts#L59) before image compression is allowed.

## Test Plan

Test with Gather app and verify that turning on image compression works.